### PR TITLE
Feature/a43 Add edit user password to member settings

### DIFF
--- a/app/Http/Controllers/Auth/EditProfileController.php
+++ b/app/Http/Controllers/Auth/EditProfileController.php
@@ -113,4 +113,15 @@ class EditProfileController extends Controller
 
         return;
     }
+
+    public function editpassword(Request $request)
+    {
+        $user = User::find($request->route('user'));
+
+        $user->password = Hash::make($request->new_password);
+        $user->temp_password = 1;
+        $user->save();
+
+        return;
+    }
 }

--- a/app/Http/Controllers/Auth/EditProfileController.php
+++ b/app/Http/Controllers/Auth/EditProfileController.php
@@ -118,6 +118,10 @@ class EditProfileController extends Controller
     {
         $user = User::find($request->route('user'));
 
+        $request->validate([
+            'new_password' => ['required', 'string', 'min:8']
+        ]);
+
         $user->password = Hash::make($request->new_password);
         $user->temp_password = 1;
         $user->save();

--- a/public/assets/css/xcs-int/custom.css
+++ b/public/assets/css/xcs-int/custom.css
@@ -30,7 +30,7 @@
 }
 
 .content-wrapper
-{   
+{
   min-height: 100vh;
 }
 
@@ -73,4 +73,10 @@ textarea:focus, input:focus {
 .select2-container--default .select2-results__option[aria-selected=true] {
   background-color: #ddd;
   color: #000000 !important;
+}
+
+.swal-content__input,
+.swal-content__input:active,
+.swal-content__input:focus{
+    color: black !important;
 }

--- a/public/js/modals/edit_profile_modal_EDIT.js
+++ b/public/js/modals/edit_profile_modal_EDIT.js
@@ -112,8 +112,8 @@ function changePasswordPopup() {
         modalNode.attr('tabindex', '-1');
         modalNode.removeClass('js-swal-fixed');
 
-        if(newPassword.length < 4) {
-            return swal("Password too short! Temporary passwords need to be at least 3 characters long.", {
+        if(newPassword.length < 7) {
+            return swal("Password too short! Temporary passwords need to be at least 8 characters long.", {
                 icon: "error"
             });
         }

--- a/public/js/modals/edit_profile_modal_EDIT.js
+++ b/public/js/modals/edit_profile_modal_EDIT.js
@@ -79,13 +79,13 @@ function changePasswordPopup() {
 
     swal({
         title: 'Are you sure?',
-        text: "The password you enter here will be a temporary password, one that you can provide to the user to use to sign in. After they have used this password, they will be forced to change the password before being allowed to continue.",
+        text: "The password you enter here will be a temporary password, one that you can provide to the user to use to sign in. After they have used this password, they will be forced to set a new password before being allowed to continue.",
         icon: 'warning',
         content: {
           element: "input",
           attributes: {
-            placeholder: "Type your password",
-            type: "password",
+            placeholder: "Type a new password here",
+            type: "text",
             class: 'form-control'
           },
         },
@@ -105,11 +105,31 @@ function changePasswordPopup() {
             closeModal: true,
           }
         }
-    }).then(() => {
+    }).then(newPassword => {
         let modalNode = $('.js-swal-fixed')
         if (!modalNode) return;
 
         modalNode.attr('tabindex', '-1');
         modalNode.removeClass('js-swal-fixed');
+
+        if(newPassword.length < 4) {
+            return swal("Password too short! Temporary passwords need to be at least 3 characters long.", {
+                icon: "error"
+            });
+        }
+
+        swal.close();
+
+        $.ajax({
+            type: 'POST',
+            url: $url_edit_profile_password_modal_POST + $('#ajax_edit_member_save').val(),
+            data: {new_password: newPassword},
+            success: function() {
+                showSuccessToast_EditMember();
+                if ($('#tableElement').length) {
+                    $('#tableElement').DataTable().ajax.reload();
+                }
+            },
+        });
     })
 }

--- a/public/js/modals/edit_profile_modal_EDIT.js
+++ b/public/js/modals/edit_profile_modal_EDIT.js
@@ -69,3 +69,47 @@ $('#ajax_edit_member').on('submit', function(e) {
   }
   });
 });
+
+function changePasswordPopup() {
+    let modalNode = $('div[tabindex*="-1"]')
+    if (!modalNode) return;
+
+    modalNode.removeAttr('tabindex');
+    modalNode.addClass('js-swal-fixed');
+
+    swal({
+        title: 'Are you sure?',
+        text: "The password you enter here will be a temporary password, one that you can provide to the user to use to sign in. After they have used this password, they will be forced to change the password before being allowed to continue.",
+        icon: 'warning',
+        content: {
+          element: "input",
+          attributes: {
+            placeholder: "Type your password",
+            type: "password",
+            class: 'form-control'
+          },
+        },
+        buttons: {
+          confirm: {
+            text: "Change Password",
+            value: true,
+            visible: true,
+            className: "btn btn-primary",
+            closeModal: true
+          },
+          cancel: {
+            text: "Cancel",
+            value: null,
+            visible: true,
+            className: "btn btn-danger",
+            closeModal: true,
+          }
+        }
+    }).then(() => {
+        let modalNode = $('.js-swal-fixed')
+        if (!modalNode) return;
+
+        modalNode.attr('tabindex', '-1');
+        modalNode.removeClass('js-swal-fixed');
+    })
+}

--- a/resources/views/master/app.blade.php
+++ b/resources/views/master/app.blade.php
@@ -86,6 +86,7 @@
     <script src="/assets/vendors/jquery-toast-plugin/jquery.toast.min.js"></script>
     <script src="/assets/vendors/datatables.net/jquery.dataTables.js"></script>
     <script src="/assets/vendors/datatables.net-bs4/dataTables.bootstrap4.js"></script>
+    <script src="/assets/vendors/sweetalert/sweetalert.min.js"></script>
     @yield('pluginjs')
     <!-- endinject -->
 

--- a/resources/views/modals/edit_profile_modal.blade.php
+++ b/resources/views/modals/edit_profile_modal.blade.php
@@ -193,11 +193,6 @@
                       <label>Antelope Password</label>
                       <button type="button" class="form-control btn btn-outline-warning btn-fw" onclick="changePasswordPopup()">Change User Password</button>
                     </div>
-                    @else
-                    <div class="form-group" hidden>
-                      <label hidden>Antelope Username</label>
-                      <input type="text" class="form-control p_input" id="profile-username-field" name="username" autocomplete="username" autofocus value="ajax-profile-display-input-username" disabled hidden>
-                    </div>
                     @endif
 
                   </div>
@@ -233,7 +228,6 @@
   var $url_edit_profile_modal_POST = '{{ url('member/edit/edit_user/') }}/';
   var $url_edit_profile_password_modal_POST = '{{ url('member/edit/edit_user_password/') }}/';
 </script>
-<script src="/assets/vendors/sweetalert/sweetalert.min.js"></script>
 <script src="/js/modals/edit_profile_modal_EDIT.js"></script>
 @endif
 

--- a/resources/views/modals/edit_profile_modal.blade.php
+++ b/resources/views/modals/edit_profile_modal.blade.php
@@ -231,6 +231,7 @@
 @if(Auth::user()->level() >= $constants['access_level']['seniorstaff'])
 <script type="text/javascript">
   var $url_edit_profile_modal_POST = '{{ url('member/edit/edit_user/') }}/';
+  var $url_edit_profile_password_modal_POST = '{{ url('member/edit/edit_user_password/') }}/';
 </script>
 <script src="/assets/vendors/sweetalert/sweetalert.min.js"></script>
 <script src="/js/modals/edit_profile_modal_EDIT.js"></script>

--- a/resources/views/modals/edit_profile_modal.blade.php
+++ b/resources/views/modals/edit_profile_modal.blade.php
@@ -188,6 +188,18 @@
                     </div>
                     @endif
 
+                    @if(Auth::user()->level() >= $constants['access_level']['admin'])
+                    <div class="form-group">
+                      <label>Antelope Password</label>
+                      <button type="button" class="form-control btn btn-outline-warning btn-fw" onclick="changePasswordPopup()">Change User Password</button>
+                    </div>
+                    @else
+                    <div class="form-group" hidden>
+                      <label hidden>Antelope Username</label>
+                      <input type="text" class="form-control p_input" id="profile-username-field" name="username" autocomplete="username" autofocus value="ajax-profile-display-input-username" disabled hidden>
+                    </div>
+                    @endif
+
                   </div>
                 </div>
               </div>
@@ -220,6 +232,7 @@
 <script type="text/javascript">
   var $url_edit_profile_modal_POST = '{{ url('member/edit/edit_user/') }}/';
 </script>
+<script src="/assets/vendors/sweetalert/sweetalert.min.js"></script>
 <script src="/js/modals/edit_profile_modal_EDIT.js"></script>
 @endif
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -95,6 +95,7 @@ Route::post('/discipline/get_data/{id}', 'AntelopeDiscipline@getDiscipline')->mi
 Route::post('/discipline/edit/{id}', 'AntelopeDiscipline@edit')->middleware('level:'.\Config::get('constants.access_level.sit'));
 Route::post('/member/edit/get_data/{user}', 'Auth\EditProfileController@userdata')->middleware('level:'.\Config::get('constants.access_level.sit'));
 Route::post('/member/edit/edit_user/{user}', 'Auth\EditProfileController@edit')->middleware('level:'.\Config::get('constants.access_level.sit'));
+Route::post('/member/edit/edit_user_password/{user}', 'Auth\EditProfileController@editpassword')->middleware('level:'.\Config::get('constants.access_level.admin'));
 Route::post('/activity/get_data/{user}', 'AntelopeActivity@passActivityInstance');
 Route::post('/activity/submit', 'AntelopeActivity@submit')->middleware('level:'.\Config::get('constants.access_level.member'));
 Route::post('/superadmin/godmode', 'Antelope@superAdminGodmode')->middleware('level:'.\Config::get('constants.access_level.superadmin'));


### PR DESCRIPTION
This PR allows admins to change a user's password to a temp password of their choosing. Temp passwords must be at least 3 characters long.

This PR adds a `editpassword` method to the  Edit Profile controller; adds custom css to the custom.css file to override css injected by js by sweetalerts; adds a sweetalert to the js file for the edit profile model; adds a new route for the previously mentioned controller.